### PR TITLE
InputLocale to en-US

### DIFF
--- a/http/windows-server-2019/Autounattend.xml
+++ b/http/windows-server-2019/Autounattend.xml
@@ -55,7 +55,7 @@
             <SetupUILanguage>
                 <UILanguage>en-US</UILanguage>
             </SetupUILanguage>
-            <InputLocale>de-DE</InputLocale>
+            <InputLocale>en-US</InputLocale>
             <SystemLocale>en-US</SystemLocale>
             <UILanguage>en-US</UILanguage>
             <UserLocale>en-US</UserLocale>

--- a/http/windows-server-2022/Autounattend.xml
+++ b/http/windows-server-2022/Autounattend.xml
@@ -55,7 +55,7 @@
             <SetupUILanguage>
                 <UILanguage>en-US</UILanguage>
             </SetupUILanguage>
-            <InputLocale>de-DE</InputLocale>
+            <InputLocale>en-US</InputLocale>
             <SystemLocale>en-US</SystemLocale>
             <UILanguage>en-US</UILanguage>
             <UserLocale>en-US</UserLocale>

--- a/http/windows-server-2025/Autounattend.xml
+++ b/http/windows-server-2025/Autounattend.xml
@@ -55,7 +55,7 @@
             <SetupUILanguage>
                 <UILanguage>en-US</UILanguage>
             </SetupUILanguage>
-            <InputLocale>de-DE</InputLocale>
+            <InputLocale>en-US</InputLocale>
             <SystemLocale>en-US</SystemLocale>
             <UILanguage>en-US</UILanguage>
             <UserLocale>en-US</UserLocale>


### PR DESCRIPTION
This sets the default input "keyboard" language to en-US.

Probably this should be solved with a variable. 

It is also very convenient for my German keyboard 🎈 but we live in a global world.