### PR TITLE
Ignore auto.pkrvars.hcl files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ packer_cache/
 *.iso
 !Autounattend.iso
 packer.exe
+*.auto.pkrvars.hcl


### PR DESCRIPTION
Packer can automatically load *.auto.pkrvars.hcl files.

They are attached in lexical order.

We should ignore them in .gitignore