### PR TITLE
Generalize templates: machine-id reset, full cloud-init/SSH/log cleanup on Linux, Sysprep on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ Example:
 & ([scriptblock]::Create((irm "https://debloat.raphi.re/"))) -RunDefaults -Sysprep -Silent
 ```
 
+## Template Generalization
+
+All templates are generalized before being sealed, so clones get unique identities.
+
+**Linux** (via the shell provisioner in each `*.pkrvars.hcl`): `cloud-init clean --logs` resets cloud-init state, SSH host keys are deleted (cloud-init regenerates them on first boot), `/etc/machine-id` is emptied so every clone gets a fresh machine ID (prevents duplicate DHCP leases with systemd-networkd), the `packer` build user is removed including its home directory, and package caches, shell history and logs are wiped. A final `fstrim` keeps the thin-provisioned disk small.
+
+**Windows** (via `http/windows-scripts/sysprep.ps1`): the Windows Update download cache, temp directories and event logs are cleaned, then the image is sealed with `sysprep /generalize /oobe /mode:vm`, which resets the machine SID and computer name. On the first boot of a clone, Windows runs the specialize/OOBE passes answered by `http/windows/sysprep-unattend-*.xml.pkrtpl` (a random computer name is generated, WinRM is re-enabled via a persisted copy of `setup.ps1`), so expect one or two extra reboots before the clone is reachable via WinRM/Ansible. Note: sysprep can fail on Windows 11 if per-user Appx packages were updated during the build; the Win11Debloat custom script above is a common mitigation.
+
 ## Useful Tips
 
 ### Packer Webserver Forwarding

--- a/almalinux-10.pkrvars.hcl
+++ b/almalinux-10.pkrvars.hcl
@@ -15,5 +15,13 @@ boot_command = [
     "<enter>"
 ]
 provisioner = [
-  "userdel --remove --force packer"
+  "cloud-init clean --logs",
+  "rm -f /etc/ssh/ssh_host_*",
+  "truncate -s 0 /etc/machine-id",
+  "rm -f /var/lib/dbus/machine-id",
+  "dnf clean all",
+  "userdel --remove --force packer",
+  "rm -f /root/.bash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/almalinux-9.pkrvars.hcl
+++ b/almalinux-9.pkrvars.hcl
@@ -7,5 +7,13 @@ http_directory = "./http/almalinux-9"
 boot_wait      = "5s"
 boot_command = ["<tab> text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"]
 provisioner = [
-  "userdel --remove --force packer"
+  "cloud-init clean --logs",
+  "rm -f /etc/ssh/ssh_host_*",
+  "truncate -s 0 /etc/machine-id",
+  "rm -f /var/lib/dbus/machine-id",
+  "dnf clean all",
+  "userdel --remove --force packer",
+  "rm -f /root/.bash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/alpine-3.21.pkrvars.hcl
+++ b/alpine-3.21.pkrvars.hcl
@@ -38,5 +38,11 @@ provisioner = [
   "echo \"datasource_list: ['NoCloud']\" > /etc/cloud/cloud.cfg.d/02-datasource.cfg",
   "echo \"PasswordAuthentication yes\" > /etc/ssh/sshd_config.d/01-password-auth.conf",
   "passwd -l root",
-  "deluser --remove-home packer"
+  "cloud-init clean --logs",
+  "rm -f /etc/ssh/ssh_host_*",
+  "rm -f /etc/machine-id /var/lib/dbus/machine-id",
+  "deluser --remove-home packer",
+  "rm -f /root/.ash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/alpine-3.22.pkrvars.hcl
+++ b/alpine-3.22.pkrvars.hcl
@@ -38,5 +38,11 @@ provisioner = [
   "echo \"datasource_list: ['NoCloud']\" > /etc/cloud/cloud.cfg.d/02-datasource.cfg",
   "echo \"PasswordAuthentication yes\" > /etc/ssh/sshd_config.d/01-password-auth.conf",
   "passwd -l root",
-  "deluser --remove-home packer"
+  "cloud-init clean --logs",
+  "rm -f /etc/ssh/ssh_host_*",
+  "rm -f /etc/machine-id /var/lib/dbus/machine-id",
+  "deluser --remove-home packer",
+  "rm -f /root/.ash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/alpine-3.23.pkrvars.hcl
+++ b/alpine-3.23.pkrvars.hcl
@@ -38,5 +38,11 @@ provisioner = [
   "echo \"datasource_list: ['NoCloud']\" > /etc/cloud/cloud.cfg.d/02-datasource.cfg",
   "echo \"PasswordAuthentication yes\" > /etc/ssh/sshd_config.d/01-password-auth.conf",
   "passwd -l root",
-  "deluser --remove-home packer"
+  "cloud-init clean --logs",
+  "rm -f /etc/ssh/ssh_host_*",
+  "rm -f /etc/machine-id /var/lib/dbus/machine-id",
+  "deluser --remove-home packer",
+  "rm -f /root/.ash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/alpine-3.24.pkrvars.hcl
+++ b/alpine-3.24.pkrvars.hcl
@@ -38,5 +38,11 @@ provisioner = [
   "echo \"datasource_list: ['NoCloud']\" > /etc/cloud/cloud.cfg.d/02-datasource.cfg",
   "echo \"PasswordAuthentication yes\" > /etc/ssh/sshd_config.d/01-password-auth.conf",
   "passwd -l root",
-  "deluser --remove-home packer"
+  "cloud-init clean --logs",
+  "rm -f /etc/ssh/ssh_host_*",
+  "rm -f /etc/machine-id /var/lib/dbus/machine-id",
+  "deluser --remove-home packer",
+  "rm -f /root/.ash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/debian-11.pkrvars.hcl
+++ b/debian-11.pkrvars.hcl
@@ -25,6 +25,14 @@ boot_command = [
   "<enter>"
 ]
 provisioner = [
-  "userdel --remove --force packer"
+  "cloud-init clean --logs",
+  "rm -f /etc/ssh/ssh_host_*",
+  "truncate -s 0 /etc/machine-id",
+  "rm -f /var/lib/dbus/machine-id",
+  "apt-get clean",
+  "userdel --remove --force packer",
+  "rm -f /root/.bash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]
 

--- a/debian-12.pkrvars.hcl
+++ b/debian-12.pkrvars.hcl
@@ -25,5 +25,13 @@ boot_command = [
   "<enter>"
 ]
 provisioner = [
-  "userdel --remove --force packer"
+  "cloud-init clean --logs",
+  "rm -f /etc/ssh/ssh_host_*",
+  "truncate -s 0 /etc/machine-id",
+  "rm -f /var/lib/dbus/machine-id",
+  "apt-get clean",
+  "userdel --remove --force packer",
+  "rm -f /root/.bash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/debian-13.pkrvars.hcl
+++ b/debian-13.pkrvars.hcl
@@ -25,5 +25,13 @@ boot_command = [
   "<enter>"
 ]
 provisioner = [
-  "userdel --remove --force packer"
+  "cloud-init clean --logs",
+  "rm -f /etc/ssh/ssh_host_*",
+  "truncate -s 0 /etc/machine-id",
+  "rm -f /var/lib/dbus/machine-id",
+  "apt-get clean",
+  "userdel --remove --force packer",
+  "rm -f /root/.bash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/generic.pkr.hcl
+++ b/generic.pkr.hcl
@@ -138,4 +138,12 @@ build {
       skip_clean      = true
     }
   }
+
+  dynamic "provisioner" {
+    for_each = length(var.provisioner_windows) > 0 ? [1] : []
+    labels = ["powershell"]
+    content {
+      inline = var.provisioner_windows
+    }
+  }
 }

--- a/http/windows-scripts/sysprep.ps1
+++ b/http/windows-scripts/sysprep.ps1
@@ -1,0 +1,43 @@
+$ErrorActionPreference = "Stop"
+
+# --- Cleanup before sealing the template ---
+
+# Windows Update download cache
+Stop-Service -Name wuauserv -Force -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force "$env:SystemRoot\SoftwareDistribution\Download\*" -ErrorAction SilentlyContinue
+
+# Temp directories
+Remove-Item -Recurse -Force "$env:SystemRoot\Temp\*" -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force "$env:TEMP\*" -ErrorAction SilentlyContinue
+
+# Persist the first-boot setup script so clones can re-enable WinRM after sysprep
+# (the script CDs are not attached to cloned VMs)
+New-Item -ItemType Directory -Path "$env:SystemRoot\Setup\Scripts" -Force | Out-Null
+Copy-Item -Path "$PSScriptRoot\setup.ps1" -Destination "$env:SystemRoot\Setup\Scripts\setup.ps1" -Force
+
+# Find the templated sysprep unattend file on the unattended CD
+$unattend = Get-PSDrive -PSProvider FileSystem |
+    ForEach-Object { Join-Path $_.Root "sysprep-unattend.xml" } |
+    Where-Object { Test-Path $_ } |
+    Select-Object -First 1
+if (-not $unattend) { throw "sysprep-unattend.xml not found on any attached drive" }
+Copy-Item -Path $unattend -Destination "$env:SystemRoot\Panther\unattend.xml" -Force
+
+# Clear event logs (last, so the cleanup noise is gone too)
+$ErrorActionPreference = "SilentlyContinue"
+wevtutil el | ForEach-Object { wevtutil cl $_ }
+$ErrorActionPreference = "Stop"
+
+# --- Generalize ---
+# /quit instead of /shutdown: packer performs the shutdown itself after the provisioner.
+# /mode:vm is safe here because clones run on the same virtual hardware.
+Start-Process -FilePath "$env:SystemRoot\System32\Sysprep\sysprep.exe" `
+    -ArgumentList "/generalize", "/oobe", "/mode:vm", "/quiet", "/quit", "/unattend:$env:SystemRoot\Panther\unattend.xml" `
+    -Wait -NoNewWindow
+
+# Verify sysprep succeeded (GeneralizationState 7 = generalization complete)
+$state = (Get-ItemProperty -Path "HKLM:\SYSTEM\Setup\Status\SysprepStatus").GeneralizationState
+if ($state -ne 7) {
+    Get-Content "$env:SystemRoot\System32\Sysprep\Panther\setuperr.log" -ErrorAction SilentlyContinue
+    throw "Sysprep failed, GeneralizationState=$state"
+}

--- a/http/windows/sysprep-unattend-server.xml.pkrtpl
+++ b/http/windows/sysprep-unattend-server.xml.pkrtpl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Answer file for the specialize/oobe passes that run on the FIRST BOOT OF A CLONE
+     after the template was sealed with "sysprep /generalize /oobe". -->
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <ComputerName>*</ComputerName>
+            <TimeZone>UTC</TimeZone>
+        </component>
+    </settings>
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>${windows_input_language}</InputLocale>
+            <SystemLocale>${windows_language}</SystemLocale>
+            <UILanguage>${windows_language}</UILanguage>
+            <UserLocale>${windows_language}</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <AutoLogon>
+                <Enabled>true</Enabled>
+                <LogonCount>1</LogonCount>
+                <Username>Administrator</Username>
+                <Password>
+                    <Value>${winrm_password}</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+            </AutoLogon>
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <Order>1</Order>
+                    <!-- Re-enable WinRM (persisted to disk by sysprep.ps1) -->
+                    <CommandLine>powershell -NoProfile -ExecutionPolicy Bypass -File C:\Windows\Setup\Scripts\setup.ps1</CommandLine>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+            <OOBE>
+                <ProtectYourPC>3</ProtectYourPC>
+                <HideEULAPage>true</HideEULAPage>
+                <HideLocalAccountScreen>true</HideLocalAccountScreen>
+                <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+            </OOBE>
+            <UserAccounts>
+                <AdministratorPassword>
+                    <Value>${winrm_password}</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+            </UserAccounts>
+        </component>
+    </settings>
+</unattend>

--- a/http/windows/sysprep-unattend-win11.xml.pkrtpl
+++ b/http/windows/sysprep-unattend-win11.xml.pkrtpl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Answer file for the specialize/oobe passes that run on the FIRST BOOT OF A CLONE
+     after the template was sealed with "sysprep /generalize /oobe".
+     The local account created during install survives sysprep, so it is only
+     used for autologon here, not re-created. -->
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <ComputerName>*</ComputerName>
+            <TimeZone>UTC</TimeZone>
+        </component>
+    </settings>
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>${windows_input_language}</InputLocale>
+            <SystemLocale>${windows_language}</SystemLocale>
+            <UILanguage>${windows_language}</UILanguage>
+            <UserLocale>${windows_language}</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <AutoLogon>
+                <Enabled>true</Enabled>
+                <LogonCount>1</LogonCount>
+                <Username>${winrm_username}</Username>
+                <Password>
+                    <Value>${winrm_password}</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+            </AutoLogon>
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <Order>1</Order>
+                    <!-- Re-enable WinRM (persisted to disk by sysprep.ps1) -->
+                    <CommandLine>powershell -NoProfile -ExecutionPolicy Bypass -File C:\Windows\Setup\Scripts\setup.ps1</CommandLine>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+            <OOBE>
+                <ProtectYourPC>3</ProtectYourPC>
+                <HideEULAPage>true</HideEULAPage>
+                <HideLocalAccountScreen>true</HideLocalAccountScreen>
+                <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <SkipUserOOBE>true</SkipUserOOBE>
+                <SkipMachineOOBE>true</SkipMachineOOBE>
+            </OOBE>
+        </component>
+    </settings>
+</unattend>

--- a/rocky-10.pkrvars.hcl
+++ b/rocky-10.pkrvars.hcl
@@ -15,5 +15,13 @@ boot_command = [
     "<enter>"
 ]
 provisioner = [
-  "userdel --remove --force packer"
+  "cloud-init clean --logs",
+  "rm -f /etc/ssh/ssh_host_*",
+  "truncate -s 0 /etc/machine-id",
+  "rm -f /var/lib/dbus/machine-id",
+  "dnf clean all",
+  "userdel --remove --force packer",
+  "rm -f /root/.bash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/rocky-9.pkrvars.hcl
+++ b/rocky-9.pkrvars.hcl
@@ -7,5 +7,13 @@ http_directory = "./http/rocky-9"
 boot_wait      = "5s"
 boot_command = ["<tab> text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"]
 provisioner = [
-  "userdel --remove --force packer"
+  "cloud-init clean --logs",
+  "rm -f /etc/ssh/ssh_host_*",
+  "truncate -s 0 /etc/machine-id",
+  "rm -f /var/lib/dbus/machine-id",
+  "dnf clean all",
+  "userdel --remove --force packer",
+  "rm -f /root/.bash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/ubuntu-18.04.pkrvars.hcl
+++ b/ubuntu-18.04.pkrvars.hcl
@@ -20,5 +20,13 @@ boot_command = [
   "<enter>"
 ]
 provisioner = [
-  "userdel --remove --force packer"
+  "cloud-init clean --logs",
+  "rm -f /etc/ssh/ssh_host_*",
+  "truncate -s 0 /etc/machine-id",
+  "rm -f /var/lib/dbus/machine-id",
+  "apt-get clean",
+  "userdel --remove --force packer",
+  "rm -f /root/.bash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/ubuntu-20.04.pkrvars.hcl
+++ b/ubuntu-20.04.pkrvars.hcl
@@ -11,7 +11,14 @@ boot_command = [
   "<enter>"
 ]
 provisioner = [
-  "cloud-init clean",
+  "cloud-init clean --logs",
   "rm /etc/cloud/cloud.cfg.d/*",
-  "userdel --remove --force packer"
+  "rm -f /etc/ssh/ssh_host_*",
+  "truncate -s 0 /etc/machine-id",
+  "rm -f /var/lib/dbus/machine-id",
+  "apt-get clean",
+  "userdel --remove --force packer",
+  "rm -f /root/.bash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/ubuntu-22.04.pkrvars.hcl
+++ b/ubuntu-22.04.pkrvars.hcl
@@ -15,7 +15,14 @@ boot_command = [
   "<enter>"
 ]
 provisioner = [
-  "cloud-init clean",
+  "cloud-init clean --logs",
   "rm /etc/cloud/cloud.cfg.d/*",
-  "userdel --remove --force packer"
+  "rm -f /etc/ssh/ssh_host_*",
+  "truncate -s 0 /etc/machine-id",
+  "rm -f /var/lib/dbus/machine-id",
+  "apt-get clean",
+  "userdel --remove --force packer",
+  "rm -f /root/.bash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/ubuntu-24.04.pkrvars.hcl
+++ b/ubuntu-24.04.pkrvars.hcl
@@ -15,7 +15,14 @@ boot_command = [
   "<enter>"
 ]
 provisioner = [
-  "cloud-init clean",
+  "cloud-init clean --logs",
   "rm /etc/cloud/cloud.cfg.d/*",
-  "userdel --remove --force packer"
+  "rm -f /etc/ssh/ssh_host_*",
+  "truncate -s 0 /etc/machine-id",
+  "rm -f /var/lib/dbus/machine-id",
+  "apt-get clean",
+  "userdel --remove --force packer",
+  "rm -f /root/.bash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/ubuntu-26.04.pkrvars.hcl
+++ b/ubuntu-26.04.pkrvars.hcl
@@ -18,7 +18,14 @@ boot_command = [
   "<enter>"
 ]
 provisioner = [
-  "cloud-init clean",
+  "cloud-init clean --logs",
   "rm /etc/cloud/cloud.cfg.d/*",
-  "userdel --remove --force packer"
+  "rm -f /etc/ssh/ssh_host_*",
+  "truncate -s 0 /etc/machine-id",
+  "rm -f /var/lib/dbus/machine-id",
+  "apt-get clean",
+  "userdel --remove --force packer",
+  "rm -f /root/.bash_history",
+  "find /var/log -type f -exec truncate -s 0 {} +",
+  "fstrim -a || true"
 ]

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -356,6 +356,12 @@ variable "provisioner" {
   type        = list(string)
 }
 
+variable "provisioner_windows" {
+  description = "The packer powershell provisioner commands (Windows builds only)."
+  type        = list(string)
+  default     = []
+}
+
 variable "packer_http_interface" {
   description = "Name of the network interface that Packer gets HTTPIP from. Defaults to the first non loopback interface."
   type        = string

--- a/windows-11.pkrvars.hcl
+++ b/windows-11.pkrvars.hcl
@@ -18,6 +18,12 @@ unattended_content = {
       image_name      = "Windows 11 Enterprise Evaluation"
     }
   }
+  "/sysprep-unattend.xml" = {
+    template = "./http/windows/sysprep-unattend-win11.xml.pkrtpl"
+    vars = {
+      image_name = ""
+    }
+  }
 }
 additional_cd_files = [
   {
@@ -32,3 +38,6 @@ http_directory = ""
 cloud_init   = false
 boot_command   = []
 provisioner    = []
+provisioner_windows = [
+  "$sysprep = Get-PSDrive -PSProvider FileSystem | ForEach-Object { Join-Path $_.Root 'sysprep.ps1' } | Where-Object { Test-Path $_ } | Select-Object -First 1; powershell -NoProfile -ExecutionPolicy Bypass -File $sysprep"
+]

--- a/windows-server-2019.pkrvars.hcl
+++ b/windows-server-2019.pkrvars.hcl
@@ -18,6 +18,12 @@ unattended_content = {
       image_name      = "Windows Server 2019 SERVERSTANDARD"
     }
   }
+  "/sysprep-unattend.xml" = {
+    template = "./http/windows/sysprep-unattend-server.xml.pkrtpl"
+    vars = {
+      image_name = ""
+    }
+  }
 }
 additional_cd_files = [
   {
@@ -32,3 +38,6 @@ http_directory = ""
 cloud_init   = false
 boot_command   = []
 provisioner    = []
+provisioner_windows = [
+  "$sysprep = Get-PSDrive -PSProvider FileSystem | ForEach-Object { Join-Path $_.Root 'sysprep.ps1' } | Where-Object { Test-Path $_ } | Select-Object -First 1; powershell -NoProfile -ExecutionPolicy Bypass -File $sysprep"
+]

--- a/windows-server-2022.pkrvars.hcl
+++ b/windows-server-2022.pkrvars.hcl
@@ -18,6 +18,12 @@ unattended_content = {
       image_name      = "Windows Server 2022 SERVERSTANDARD"
     }
   }
+  "/sysprep-unattend.xml" = {
+    template = "./http/windows/sysprep-unattend-server.xml.pkrtpl"
+    vars = {
+      image_name = ""
+    }
+  }
 }
 additional_cd_files = [
   {
@@ -32,3 +38,6 @@ http_directory = ""
 cloud_init   = false
 boot_command   = []
 provisioner    = []
+provisioner_windows = [
+  "$sysprep = Get-PSDrive -PSProvider FileSystem | ForEach-Object { Join-Path $_.Root 'sysprep.ps1' } | Where-Object { Test-Path $_ } | Select-Object -First 1; powershell -NoProfile -ExecutionPolicy Bypass -File $sysprep"
+]

--- a/windows-server-2025.pkrvars.hcl
+++ b/windows-server-2025.pkrvars.hcl
@@ -18,6 +18,12 @@ unattended_content = {
       image_name      = "Windows Server 2025 SERVERSTANDARD"
     }
   }
+  "/sysprep-unattend.xml" = {
+    template = "./http/windows/sysprep-unattend-server.xml.pkrtpl"
+    vars = {
+      image_name = ""
+    }
+  }
 }
 additional_cd_files = [
   {
@@ -32,3 +38,6 @@ http_directory = ""
 cloud_init   = false
 boot_command   = []
 provisioner    = []
+provisioner_windows = [
+  "$sysprep = Get-PSDrive -PSProvider FileSystem | ForEach-Object { Join-Path $_.Root 'sysprep.ps1' } | Where-Object { Test-Path $_ } | Select-Object -First 1; powershell -NoProfile -ExecutionPolicy Bypass -File $sysprep"
+]


### PR DESCRIPTION
Summary
Templates were only partially generalized before conversion: Linux builds shipped a shared /etc/machine-id and SSH host keys, most distros never ran cloud-init clean, and Windows templates were never sysprepped — clones kept the same SID and computer name. This PR seals every template properly.
Linux (all distro *.pkrvars.hcl)
Every provisioner block now runs a full generalization pass:

cloud-init clean --logs on all distros (previously Ubuntu-only) so clones start with fresh cloud-init state
SSH host keys removed (rm -f /etc/ssh/ssh_host_*); cloud-init regenerates unique keys on first clone boot
/etc/machine-id emptied and /var/lib/dbus/machine-id removed — fixes clones receiving duplicate DHCP leases with systemd-networkd, which derives its DHCP client ID from the machine-id
Package caches cleaned (apt-get clean / dnf clean all), root shell history removed, /var/log truncated
fstrim -a before shutdown to shrink the thin-provisioned disk

Talos, VyOS, and OPNsense are appliance-style images and intentionally unchanged.
Windows (all four builds)

New provisioner_windows variable + dynamic powershell provisioner in generic.pkr.hcl
New http/windows-scripts/sysprep.ps1: cleans the Windows Update download cache, temp directories, and event logs, persists setup.ps1 to C:\Windows\Setup\Scripts, then seals the image with sysprep /generalize /oobe /mode:vm /quiet /quit and fails the build if generalization didn't complete (packer performs the shutdown)
New templated answer files http/windows/sysprep-unattend-{server,win11}.xml.pkrtpl handle the specialize/OOBE passes on a clone's first boot: fresh SID, random computer name, autologon once, and WinRM re-enabled via the persisted setup.ps1

Behavior changes

Windows clones now go through OOBE on first boot (one or two extra reboots) before WinRM/Ansible is reachable
Linux clones generate a fresh machine-id and SSH host keys, so each clone gets its own DHCP lease and host identity

Testing

All .hcl files parse cleanly; unattend XML templates validated as well-formed after variable substitution
Recommend packer validate plus one build per family (Ubuntu, EL, Alpine, Windows Server) before merging
Known caveat: Sysprep can fail on Windows 11 if per-user Appx packages updated during the build — the Win11Debloat custom script documented in the README is the usual mitigation