### PR TITLE
fix: make Windows Server OOBE non-interactive

### DIFF
--- a/http/windows-scripts/setup.ps1
+++ b/http/windows-scripts/setup.ps1
@@ -1,12 +1,9 @@
 $ErrorActionPreference = "Stop"
 
-# Switch network connection to private mode
-# Required for WinRM firewall rules
-$profile = Get-NetConnectionProfile
-Set-NetConnectionProfile -Name $profile.Name -NetworkCategory Private
-
-# Enable WinRM service
-winrm quickconfig -quiet
+# Enable WinRM without changing the network category. Changing it during the
+# first interactive logon can display the Windows network-discovery prompt and
+# block an unattended Packer build.
+Enable-PSRemoting -SkipNetworkProfileCheck -Force
 winrm set winrm/config/service '@{AllowUnencrypted="true"}'
 winrm set winrm/config/service/auth '@{Basic="true"}'
 

--- a/http/windows/Autounattend-server.xml.pkrtpl
+++ b/http/windows/Autounattend-server.xml.pkrtpl
@@ -159,7 +159,7 @@
                     <Order>1</Order>
                     <!-- Enable WinRM service -->
                     <CommandLine>powershell -ExecutionPolicy Bypass -File F:\setup.ps1</CommandLine>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <!-- Configure Remote execution for ansible -->
@@ -176,6 +176,8 @@
                 <ProtectYourPC>3</ProtectYourPC>
                 <HideEULAPage>true</HideEULAPage>
                 <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <SkipUserOOBE>true</SkipUserOOBE>
+                <SkipMachineOOBE>true</SkipMachineOOBE>
             </OOBE>
             <UserAccounts>
                 <AdministratorPassword>


### PR DESCRIPTION
$Fixes Volfieldd/psychic-tribble#486\n\nRemoves the first-logon network-profile mutation that opens the Windows discovery prompt, enables WinRM without a private network profile, and makes Server 2019 OOBE non-interactive.\n\nValidation: XML parse and Packer validate with non-sensitive placeholder runtime variables.